### PR TITLE
build: restrict target repository

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   mkdocs:
+    if: github.repository == 'GideokKim/google-python-style-guide-kr'  # upstream 저장소 확인
     runs-on: ubuntu-24.04
     environment:
       name: github-pages


### PR DESCRIPTION
현재 다른 분들의 저장소에서도 배포 시도롤 하고 있어 upstream 저장소에서만 GitHub Action이 동작하도록 제한하는 수정사항입니다.