### PR TITLE
📝 fix: mkdocs에서 github alert 구문을 옳게 표시하도록 수정

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ markdown_extensions:
   - tables                # 테이블
   - toc:                  # 목차
       permalink: true
+  - github-callouts
 
 # Plugins
 plugins:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ mkdocs
 mkdocs-material>=9.0
 mkdocs-material-extensions
 pymdown-extensions
+markdown-callouts
 
 markdown
 Pygments # https://pygments.org/


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/858490dc-06e6-4f2e-a004-dfc6ca0b3ae0)

**After:**
![image](https://github.com/user-attachments/assets/90df1f11-9892-4775-95ae-5f7a41a1e3c9)


다양한 admonitions 구문을 인식하도록 해주는 `markdown-callouts` 확장을 의존성에 추가하고, `mkdocs.yml`에 `github-callouts`를 확장으로서 추가했습니다.